### PR TITLE
セキュリティ対策

### DIFF
--- a/project/app/Http/Controllers/LocalLocalController.php
+++ b/project/app/Http/Controllers/LocalLocalController.php
@@ -39,7 +39,9 @@ class LocalLocalController extends Controller
     public function store(Request $request)
     {
         $data = new Comparison;
-        $comparison = $data->create($request->all());
+        $request_data = $request->all();
+        $request_data['user_id'] = Auth::id();
+        $comparison = $data->create($request_data);
         return redirect(route('locallocal.read', ['id' => $comparison->id]));
     }
 

--- a/project/app/Http/Controllers/LocalLocalController.php
+++ b/project/app/Http/Controllers/LocalLocalController.php
@@ -77,19 +77,6 @@ class LocalLocalController extends Controller
         //
     }
 
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy($id)
-    {
-        $data = Comparison::find($id);
-        $data->delete();
-        return redirect('/locallocal');
-    }
-
     // 読み込み用
     public function read($id)
     {

--- a/project/app/Http/Controllers/YouLocalController.php
+++ b/project/app/Http/Controllers/YouLocalController.php
@@ -39,7 +39,9 @@ class YouLocalController extends Controller
     public function store(Request $request)
     {
         $data = new Comparison;
-        $comparison = $data->create($request->all());
+        $request_data = $request->all();
+        $request_data['user_id'] = Auth::id();
+        $comparison = $data->create($request_data);
         return redirect(route('youlocal.read', ['id' => $comparison->id]));
     }
 

--- a/project/app/Http/Controllers/YouLocalController.php
+++ b/project/app/Http/Controllers/YouLocalController.php
@@ -77,19 +77,6 @@ class YouLocalController extends Controller
         //
     }
 
-    /**
-     * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy($id)
-    {
-        $data = Comparison::find($id);
-        $data->delete();
-        return redirect('/youlocal');
-    }
-
     // 読み込み用
     public function read($id)
     {

--- a/project/app/Http/Controllers/YouYouController.php
+++ b/project/app/Http/Controllers/YouYouController.php
@@ -30,7 +30,9 @@ class YouYouController extends Controller
     public function store(Request $request)
     {
         $data = new Comparison;
-        $comparison = $data->create($request->all());
+        $request_data = $request->all();
+        $request_data['user_id'] = Auth::id();
+        $comparison = $data->create($request_data);
         return redirect(route('youyou.read', ['id' => $comparison->id]));
     }
 

--- a/project/app/Http/Controllers/YouYouController.php
+++ b/project/app/Http/Controllers/YouYouController.php
@@ -35,19 +35,6 @@ class YouYouController extends Controller
     }
 
     /**
-     * Remove the specified resource from storage.
-     *
-     * @param  int  $id
-     * @return \Illuminate\Http\Response
-     */
-    public function destroy($id)
-    {
-        $data = Comparison::find($id);
-        $data->delete();
-        return redirect('/youyou');
-    }
-
-    /**
      * ツイートから遷移してきた場合の処理
      *
      * @param Request $request

--- a/project/database/seeds/DatabaseSeeder.php
+++ b/project/database/seeds/DatabaseSeeder.php
@@ -14,7 +14,7 @@ class DatabaseSeeder extends Seeder
         DB::table('users')->insert([
             'name' => '管理者',
             'email' => 'homing0321r4cfw@yahoo.co.jp',
-            'password' => bcrypt('kxlblvfo'),
+            'password' => bcrypt('P@ssw0rd'),
             'car_type' => 'FD2',
         ]);
         DB::table('analyzes')->insert([

--- a/project/routes/web.php
+++ b/project/routes/web.php
@@ -21,7 +21,6 @@ Route::get('/lp/en', 'LPController@show_en')->name('lp.en');
 Route::get('/', 'YouYouController@index');
 Route::get('/youyou', 'YouYouController@index')->name('youyou');
 Route::post('/youyou_store', 'YouYouController@store')->name('youyou.store');
-Route::get('/youyou-destroy/{id}', 'YouYouController@destroy')->name('youyou.destroy');
 // twittercardの関係でidはクエリパラメーターで渡す
 Route::get('/youyou-tweat', 'YouYouController@tweat')->name('youyou.tweat');
 Route::get('/youyou-read/{id}', 'YouYouController@read')->name('youyou.read');
@@ -29,13 +28,11 @@ Route::get('/youyou-read/{id}', 'YouYouController@read')->name('youyou.read');
 // LocalLocal
 Route::get('/locallocal', 'LocalLocalController@index')->name('locallocal');
 Route::post('/local_store', 'LocalLocalController@store')->name('locallocal.store');
-Route::get('/locallocal_destroy/{id}', 'LocalLocalController@destroy')->name('locallocal.destroy');
 Route::get('/locallocal_read/{id}', 'LocalLocalController@read')->name('locallocal.read');
 
 // youlocal
 Route::get('/youlocal', 'YouLocalController@index')->name('youlocal');
 Route::post('/youlocal_store', 'YouLocalController@store')->name('youlocal.store');
-Route::get('/youlocal_destroy/{id}', 'YouLocalController@destroy')->name('youlocal.destroy');
 Route::get('/youlocal_read/{id}', 'YouLocalController@read')->name('youlocal.read');
 
 // ajax

--- a/project/routes/web.php
+++ b/project/routes/web.php
@@ -1,67 +1,67 @@
-<?php
+  <?php
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
+  /*
+  |--------------------------------------------------------------------------
+  | Web Routes
+  |--------------------------------------------------------------------------
+  |
+  | Here is where you can register web routes for your application. These
+  | routes are loaded by the RouteServiceProvider within a group which
+  | contains the "web" middleware group. Now create something great!
+  |
+  */
 
-Auth::routes();
+  Auth::routes();
 
-// lp
-Route::get('/lp/ja', 'LPController@show_ja')->name('lp.ja');
-Route::get('/lp/en', 'LPController@show_en')->name('lp.en');
+  // lp
+  Route::get('/lp/ja', 'LPController@show_ja')->name('lp.ja');
+  Route::get('/lp/en', 'LPController@show_en')->name('lp.en');
 
-// youyou
-Route::get('/', 'YouYouController@index');
-Route::get('/youyou', 'YouYouController@index')->name('youyou');
-Route::match(['get', 'post'], '/youyou_store', 'YouYouController@store')->name('youyou.store');
-Route::get('/youyou-destroy/{id}', 'YouYouController@destroy')->name('youyou.destroy');
-// twittercardの関係でidはクエリパラメーターで渡す
-Route::get('/youyou-tweat', 'YouYouController@tweat')->name('youyou.tweat');
-Route::get('/youyou-read/{id}', 'YouYouController@read')->name('youyou.read');
+  // youyou
+  Route::get('/', 'YouYouController@index');
+  Route::get('/youyou', 'YouYouController@index')->name('youyou');
+  Route::post('/youyou_store', 'YouYouController@store')->name('youyou.store');
+  Route::get('/youyou-destroy/{id}', 'YouYouController@destroy')->name('youyou.destroy');
+  // twittercardの関係でidはクエリパラメーターで渡す
+  Route::get('/youyou-tweat', 'YouYouController@tweat')->name('youyou.tweat');
+  Route::get('/youyou-read/{id}', 'YouYouController@read')->name('youyou.read');
 
-// LocalLocal
-Route::get('/locallocal', 'LocalLocalController@index')->name('locallocal');
-Route::match(['get', 'post'], '/local_store', 'LocalLocalController@store')->name('locallocal.store');
-Route::get('/locallocal_destroy/{id}', 'LocalLocalController@destroy')->name('locallocal.destroy');
-Route::get('/locallocal_read/{id}', 'LocalLocalController@read')->name('locallocal.read');
+  // LocalLocal
+  Route::get('/locallocal', 'LocalLocalController@index')->name('locallocal');
+  Route::post('/local_store', 'LocalLocalController@store')->name('locallocal.store');
+  Route::get('/locallocal_destroy/{id}', 'LocalLocalController@destroy')->name('locallocal.destroy');
+  Route::get('/locallocal_read/{id}', 'LocalLocalController@read')->name('locallocal.read');
 
-// youlocal
-Route::get('/youlocal', 'YouLocalController@index')->name('youlocal');
-Route::match(['get', 'post'], '/youlocal_store', 'YouLocalController@store')->name('youlocal.store');
-Route::get('/youlocal_destroy/{id}', 'YouLocalController@destroy')->name('youlocal.destroy');
-Route::get('/youlocal_read/{id}', 'YouLocalController@read')->name('youlocal.read');
+  // youlocal
+  Route::get('/youlocal', 'YouLocalController@index')->name('youlocal');
+  Route::post('/youlocal_store', 'YouLocalController@store')->name('youlocal.store');
+  Route::get('/youlocal_destroy/{id}', 'YouLocalController@destroy')->name('youlocal.destroy');
+  Route::get('/youlocal_read/{id}', 'YouLocalController@read')->name('youlocal.read');
 
-// ajax
-Route::get('/ajax/select2_comparison/{id}', 'Ajax\Select2Controller@select2_comparison')->name('ajax.select2.comparison');
-Route::get('/ajax/find-comparsion/{id}', 'Ajax\ComparsionController@find_comparsion');
-Route::get('/analysis/set/', 'Ajax\AnalysisController@set');
-Route::get('/analysis/reload/', 'Ajax\AnalysisController@reload');
-Route::get('/analysis/read/', 'Ajax\AnalysisController@read');
-Route::get('/analysis/save/', 'Ajax\AnalysisController@save');
-Route::get('/analysis/play/', 'Ajax\AnalysisController@play');
-Route::get('/analysis/stop/', 'Ajax\AnalysisController@stop');
-Route::get('/analysis/slow/', 'Ajax\AnalysisController@slow');
-Route::get('/analysis/fast/', 'Ajax\AnalysisController@fast');
-Route::get('/analysis/multiRelease/', 'Ajax\AnalysisController@multiRelease');
-Route::get('/analysis/tweat/', 'Ajax\AnalysisController@tweat');
-Route::get('/analysis/delete/', 'Ajax\AnalysisController@delete');
-Route::get('/analysis/access_youyou/', 'Ajax\AnalysisController@access_youyou');
-Route::get('/analysis/access_locallocal/', 'Ajax\AnalysisController@access_locallocal');
-Route::get('/analysis/access_youlocal/', 'Ajax\AnalysisController@access_youlocal');
+  // ajax
+  Route::get('/ajax/select2_comparison/{id}', 'Ajax\Select2Controller@select2_comparison')->name('ajax.select2.comparison');
+  Route::get('/ajax/find-comparsion/{id}', 'Ajax\ComparsionController@find_comparsion');
+  Route::get('/analysis/set/', 'Ajax\AnalysisController@set');
+  Route::get('/analysis/reload/', 'Ajax\AnalysisController@reload');
+  Route::get('/analysis/read/', 'Ajax\AnalysisController@read');
+  Route::get('/analysis/save/', 'Ajax\AnalysisController@save');
+  Route::get('/analysis/play/', 'Ajax\AnalysisController@play');
+  Route::get('/analysis/stop/', 'Ajax\AnalysisController@stop');
+  Route::get('/analysis/slow/', 'Ajax\AnalysisController@slow');
+  Route::get('/analysis/fast/', 'Ajax\AnalysisController@fast');
+  Route::get('/analysis/multiRelease/', 'Ajax\AnalysisController@multiRelease');
+  Route::get('/analysis/tweat/', 'Ajax\AnalysisController@tweat');
+  Route::get('/analysis/delete/', 'Ajax\AnalysisController@delete');
+  Route::get('/analysis/access_youyou/', 'Ajax\AnalysisController@access_youyou');
+  Route::get('/analysis/access_locallocal/', 'Ajax\AnalysisController@access_locallocal');
+  Route::get('/analysis/access_youlocal/', 'Ajax\AnalysisController@access_youlocal');
 
-// ホーム
-Route::get('/home', 'HomeController@index')->name('home');
-Route::get('/home_tweat/{id}', 'HomeController@tweat')->name('home.tweat');
-Route::get('/home_destroy/{id}', 'HomeController@destroy')->name('home.destroy');
-Route::get('/home_release_update/{id}', 'HomeController@release_update')->name('home.release_update');
+  // ホーム
+  Route::get('/home', 'HomeController@index')->name('home');
+  Route::get('/home_tweat/{id}', 'HomeController@tweat')->name('home.tweat');
+  Route::get('/home_destroy/{id}', 'HomeController@destroy')->name('home.destroy');
+  Route::get('/home_release_update/{id}', 'HomeController@release_update')->name('home.release_update');
 
-// お問い合わせ
-Route::get('contact', 'ContactsController@index')->name('contact');
-Route::post('contact/send', 'ContactsController@send')->name('contact.send');
+  // お問い合わせ
+  Route::get('contact', 'ContactsController@index')->name('contact');
+  Route::post('contact/send', 'ContactsController@send')->name('contact.send');

--- a/project/routes/web.php
+++ b/project/routes/web.php
@@ -1,67 +1,67 @@
-  <?php
+<?php
 
-  /*
-  |--------------------------------------------------------------------------
-  | Web Routes
-  |--------------------------------------------------------------------------
-  |
-  | Here is where you can register web routes for your application. These
-  | routes are loaded by the RouteServiceProvider within a group which
-  | contains the "web" middleware group. Now create something great!
-  |
-  */
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register web routes for your application. These
+| routes are loaded by the RouteServiceProvider within a group which
+| contains the "web" middleware group. Now create something great!
+|
+*/
 
-  Auth::routes();
+Auth::routes();
 
-  // lp
-  Route::get('/lp/ja', 'LPController@show_ja')->name('lp.ja');
-  Route::get('/lp/en', 'LPController@show_en')->name('lp.en');
+// lp
+Route::get('/lp/ja', 'LPController@show_ja')->name('lp.ja');
+Route::get('/lp/en', 'LPController@show_en')->name('lp.en');
 
-  // youyou
-  Route::get('/', 'YouYouController@index');
-  Route::get('/youyou', 'YouYouController@index')->name('youyou');
-  Route::post('/youyou_store', 'YouYouController@store')->name('youyou.store');
-  Route::get('/youyou-destroy/{id}', 'YouYouController@destroy')->name('youyou.destroy');
-  // twittercardの関係でidはクエリパラメーターで渡す
-  Route::get('/youyou-tweat', 'YouYouController@tweat')->name('youyou.tweat');
-  Route::get('/youyou-read/{id}', 'YouYouController@read')->name('youyou.read');
+// youyou
+Route::get('/', 'YouYouController@index');
+Route::get('/youyou', 'YouYouController@index')->name('youyou');
+Route::post('/youyou_store', 'YouYouController@store')->name('youyou.store');
+Route::get('/youyou-destroy/{id}', 'YouYouController@destroy')->name('youyou.destroy');
+// twittercardの関係でidはクエリパラメーターで渡す
+Route::get('/youyou-tweat', 'YouYouController@tweat')->name('youyou.tweat');
+Route::get('/youyou-read/{id}', 'YouYouController@read')->name('youyou.read');
 
-  // LocalLocal
-  Route::get('/locallocal', 'LocalLocalController@index')->name('locallocal');
-  Route::post('/local_store', 'LocalLocalController@store')->name('locallocal.store');
-  Route::get('/locallocal_destroy/{id}', 'LocalLocalController@destroy')->name('locallocal.destroy');
-  Route::get('/locallocal_read/{id}', 'LocalLocalController@read')->name('locallocal.read');
+// LocalLocal
+Route::get('/locallocal', 'LocalLocalController@index')->name('locallocal');
+Route::post('/local_store', 'LocalLocalController@store')->name('locallocal.store');
+Route::get('/locallocal_destroy/{id}', 'LocalLocalController@destroy')->name('locallocal.destroy');
+Route::get('/locallocal_read/{id}', 'LocalLocalController@read')->name('locallocal.read');
 
-  // youlocal
-  Route::get('/youlocal', 'YouLocalController@index')->name('youlocal');
-  Route::post('/youlocal_store', 'YouLocalController@store')->name('youlocal.store');
-  Route::get('/youlocal_destroy/{id}', 'YouLocalController@destroy')->name('youlocal.destroy');
-  Route::get('/youlocal_read/{id}', 'YouLocalController@read')->name('youlocal.read');
+// youlocal
+Route::get('/youlocal', 'YouLocalController@index')->name('youlocal');
+Route::post('/youlocal_store', 'YouLocalController@store')->name('youlocal.store');
+Route::get('/youlocal_destroy/{id}', 'YouLocalController@destroy')->name('youlocal.destroy');
+Route::get('/youlocal_read/{id}', 'YouLocalController@read')->name('youlocal.read');
 
-  // ajax
-  Route::get('/ajax/select2_comparison/{id}', 'Ajax\Select2Controller@select2_comparison')->name('ajax.select2.comparison');
-  Route::get('/ajax/find-comparsion/{id}', 'Ajax\ComparsionController@find_comparsion');
-  Route::get('/analysis/set/', 'Ajax\AnalysisController@set');
-  Route::get('/analysis/reload/', 'Ajax\AnalysisController@reload');
-  Route::get('/analysis/read/', 'Ajax\AnalysisController@read');
-  Route::get('/analysis/save/', 'Ajax\AnalysisController@save');
-  Route::get('/analysis/play/', 'Ajax\AnalysisController@play');
-  Route::get('/analysis/stop/', 'Ajax\AnalysisController@stop');
-  Route::get('/analysis/slow/', 'Ajax\AnalysisController@slow');
-  Route::get('/analysis/fast/', 'Ajax\AnalysisController@fast');
-  Route::get('/analysis/multiRelease/', 'Ajax\AnalysisController@multiRelease');
-  Route::get('/analysis/tweat/', 'Ajax\AnalysisController@tweat');
-  Route::get('/analysis/delete/', 'Ajax\AnalysisController@delete');
-  Route::get('/analysis/access_youyou/', 'Ajax\AnalysisController@access_youyou');
-  Route::get('/analysis/access_locallocal/', 'Ajax\AnalysisController@access_locallocal');
-  Route::get('/analysis/access_youlocal/', 'Ajax\AnalysisController@access_youlocal');
+// ajax
+Route::get('/ajax/select2_comparison/{id}', 'Ajax\Select2Controller@select2_comparison')->name('ajax.select2.comparison');
+Route::get('/ajax/find-comparsion/{id}', 'Ajax\ComparsionController@find_comparsion');
+Route::get('/analysis/set/', 'Ajax\AnalysisController@set');
+Route::get('/analysis/reload/', 'Ajax\AnalysisController@reload');
+Route::get('/analysis/read/', 'Ajax\AnalysisController@read');
+Route::get('/analysis/save/', 'Ajax\AnalysisController@save');
+Route::get('/analysis/play/', 'Ajax\AnalysisController@play');
+Route::get('/analysis/stop/', 'Ajax\AnalysisController@stop');
+Route::get('/analysis/slow/', 'Ajax\AnalysisController@slow');
+Route::get('/analysis/fast/', 'Ajax\AnalysisController@fast');
+Route::get('/analysis/multiRelease/', 'Ajax\AnalysisController@multiRelease');
+Route::get('/analysis/tweat/', 'Ajax\AnalysisController@tweat');
+Route::get('/analysis/delete/', 'Ajax\AnalysisController@delete');
+Route::get('/analysis/access_youyou/', 'Ajax\AnalysisController@access_youyou');
+Route::get('/analysis/access_locallocal/', 'Ajax\AnalysisController@access_locallocal');
+Route::get('/analysis/access_youlocal/', 'Ajax\AnalysisController@access_youlocal');
 
-  // ホーム
-  Route::get('/home', 'HomeController@index')->name('home');
-  Route::get('/home_tweat/{id}', 'HomeController@tweat')->name('home.tweat');
-  Route::get('/home_destroy/{id}', 'HomeController@destroy')->name('home.destroy');
-  Route::get('/home_release_update/{id}', 'HomeController@release_update')->name('home.release_update');
+// ホーム
+Route::get('/home', 'HomeController@index')->name('home');
+Route::get('/home_tweat/{id}', 'HomeController@tweat')->name('home.tweat');
+Route::get('/home_destroy/{id}', 'HomeController@destroy')->name('home.destroy');
+Route::get('/home_release_update/{id}', 'HomeController@release_update')->name('home.release_update');
 
-  // お問い合わせ
-  Route::get('contact', 'ContactsController@index')->name('contact');
-  Route::post('contact/send', 'ContactsController@send')->name('contact.send');
+// お問い合わせ
+Route::get('contact', 'ContactsController@index')->name('contact');
+Route::post('contact/send', 'ContactsController@send')->name('contact.send');


### PR DESCRIPTION
比較の保存時に任意のユーザーIDで登録できる状態になっていたのできないようにした。
不要なGETメソッドを削除(これでslackのエラー通知が減るはず)